### PR TITLE
Safer equivalence testing for IPersistentCollection implementation

### DIFF
--- a/src/lazy_map/core.clj
+++ b/src/lazy_map/core.clj
@@ -126,9 +126,8 @@
   (count [this] 2)
   (empty [this] false)
   (equiv [this o]
-    (.equiv
-      [key_ (force val_)]
-      o))
+    (and (instance? clojure.lang.IPersistentCollection o)
+         (.equiv [key_ (force val_)] o)))
 
   clojure.lang.IPersistentStack
   (peek [this] (force val_))
@@ -249,9 +248,9 @@
   (cons [this o]
     (LazyMap. (.cons (or contents {}) o)))
   (equiv [this o]
-    (.equiv
-      ^clojure.lang.IPersistentCollection
-      (into {} this) o))
+    (and (instance? clojure.lang.IPersistentCollection o)
+         (.equiv ^clojure.lang.IPersistentCollection
+                 (into {} this) o)))
 
   clojure.lang.IPersistentMap
   (assoc [this key val]


### PR DESCRIPTION
I hit the issue when trying to use lazy maps as values of an underlying map of FIFO Cache (provided by `clojure.core.cache`). After calling `clojure.core.cache.wrapped/lookup-or-miss` to add a lazy map as (missing) value associated with some cache key, it was always added in realized form.

After debugging I've found that the issue was a part of code where `clojure.core/=` was called to compare a value `v` (holding a lazy map) with a special value signalizing expiration: `::expired`. By default the `=` function uses `clojure.lang.Util/equiv` to compare two objects and `equiv` calls `clojure.lang.Util/pcequiv` when **at least one of the compared objects** implements `clojure.lang.IPersistentCollection`. Then, `pcequiv` picks one of the objects implementing `IPersistentCollection` and calls `.equiv` on it with other object's value passed as an argument.

As a result comparing lazy map with any value (like keyword, symbol or a number) causes full realization of delayed values. It is ok for comparing with other collections but when it comes to obviously non-matching objects (not collections), causes unexpected side-effects. Comparing a value with a keyword is common practice to handle special cases and therefore we should expect more scenarios like that.

Until Clojure will be changed to resolve the issue (see [CLJ-1375](https://clojure.atlassian.net/browse/CLJ-1375)) and/or `=` will be replaced by `identical?` in `core.cache`, it would be helpful to apply a workaround (the additional testing is very cheap operation).

See also:

* [Remove Util.pcequiv() and stop pretending Java colls are equiv to Clojure colls](https://ask.clojure.org/index.php/745/remove-util-pcequiv-stop-pretending-colls-equiv-clojure-colls), ask.clojure.org

